### PR TITLE
Tiles urls of groups must match with correct reverse

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ CHANGELOG
 ### Fixes
 
 * Fix bug with shapefile export on geometry defined layer.
+* Fix group's tiles URLs in tilejson
+* Fix tilejson when Layer has no Feature
 
 
 0.3.4      (2019-09-26)

--- a/geostore/tests/test_views/test_vector_tiles.py
+++ b/geostore/tests/test_views/test_vector_tiles.py
@@ -4,6 +4,7 @@ from django.core.management import call_command
 from django.db import connection
 from django.test import TestCase, override_settings
 from django.urls import reverse
+from django.utils.http import urlunquote
 from rest_framework.status import HTTP_200_OK, HTTP_404_NOT_FOUND
 from rest_framework.test import APITestCase
 
@@ -107,7 +108,7 @@ class VectorTilesTestCase(TestCase):
 
     def test_group_tilejson(self):
         response = self.client.get(
-            reverse('geostore:group-tilejson', args=[self.group_name]),
+            reverse('geostore:group-tilejson', args=[self.mygroup.slug]),
             # HTTP_HOST required to build the tilejson descriptor
             HTTP_HOST='localhost'
         )
@@ -115,10 +116,16 @@ class VectorTilesTestCase(TestCase):
         self.assertGreater(len(response.content), 0)
 
         tile_json = response.json()
+
         self.assertTrue(tile_json['attribution'])
         self.assertTrue(tile_json['description'] is None)
         self.assertGreater(len(tile_json['vector_layers']), 0)
         self.assertGreater(len(tile_json['vector_layers'][0]['fields']), 0)
+        self.assertEqual(
+            tile_json['tiles'][0],
+            urlunquote(reverse('geostore:group-tiles-pattern',
+                               args=[self.mygroup.slug]))
+        )
 
     def test_layer_tilejson(self):
         response = self.client.get(

--- a/geostore/tests/test_views/test_vector_tiles.py
+++ b/geostore/tests/test_views/test_vector_tiles.py
@@ -140,6 +140,11 @@ class VectorTilesTestCase(TestCase):
         self.assertTrue(tilejson['description'] is None)
         self.assertGreater(len(tilejson['vector_layers']), 0)
         self.assertGreater(len(tilejson['vector_layers'][0]['fields']), 0)
+        self.assertEqual(
+            tilejson['tiles'][0],
+            urlunquote(reverse('geostore:layer-tiles-pattern',
+                               args=[self.layer.pk]))
+        )
 
     def test_vector_group_tiles_view(self):
         # first query that generate the cache

--- a/geostore/tiles/mixins.py
+++ b/geostore/tiles/mixins.py
@@ -27,6 +27,9 @@ class AbstractTileJsonMixin:
     def layers(self):
         raise NotImplementedError()
 
+    def get_tile_path(self):
+        raise NotImplementedError()
+
     def get_minzoom(self):
         return max(
             app_settings.MIN_TILE_ZOOM,
@@ -42,9 +45,6 @@ class AbstractTileJsonMixin:
                 l.layer_settings_with_default('tiles', 'maxzoom')
                 for l in self.layers
             ]))
-
-    def get_tile_path(self):
-        return reverse("geostore:layer-tiles-pattern", args=[self.object.pk])
 
     def get_attribution(self):
         return ','.join(set(
@@ -137,12 +137,18 @@ class AbstractTileJsonMixin:
 
 class TileJsonMixin(AbstractTileJsonMixin):
 
+    def get_tile_path(self):
+        return reverse("geostore:layer-tiles-pattern", args=[self.object.pk])
+
     @property
     def layers(self):
         return [self.object]
 
 
 class MultipleTileJsonMixin(AbstractTileJsonMixin):
+
+    def get_tile_path(self):
+        return reverse("geostore:group-tiles-pattern", args=[self.object.slug])
 
     @property
     def layers(self):


### PR DESCRIPTION
Groups tilejson provided bad pattern urls of tiles, it used layer's tiles reverse
instead of group's ones.