### PR TITLE
Improve development stack and readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,18 @@
-FROM makinacorpus/geodjango:bionic-3.7
+FROM makinacorpus/geodjango:bionic-3.6
 
 RUN mkdir -p /code/src
-COPY . /code/src
-WORKDIR /code/src
 
 RUN useradd -ms /bin/bash django
 RUN chown -R django:django /code
 
 USER django
 
-RUN python3.7 -m venv /code/venv
+RUN python3.6 -m venv /code/venv
 RUN  /code/venv/bin/pip install --no-cache-dir pip setuptools wheel -U
+
+COPY . /code/src
+WORKDIR /code/src
 
 # Install dev requirements
 RUN /code/venv/bin/pip3 install --no-cache-dir -e .[dev] -U
+RUN . /code/venv/bin/activate

--- a/README.md
+++ b/README.md
@@ -4,31 +4,64 @@
 [![Documentation Status](https://readthedocs.org/projects/django-geostore/badge/?version=latest)](https://django-geostore.readthedocs.io/en/latest/?badge=latest)
 
 ![Python Version](https://img.shields.io/badge/python-%3E%3D%203.6-blue.svg)
-![Django Version](https://img.shields.io/badge/django-%3E%3D%202.2%2C<3.1-blue.svg)
-![Rest Version](https://img.shields.io/badge/django--rest--framework-%3E%3D%203.10.0-blue)
+![Django Version](https://img.shields.io/badge/django-%3E%3D%202.2-blue.svg)
 
 # django-geostore
 
-Dynamic geo data store with vector tiles generation and json schema definition / validation
+Dynamic geographic datastore with vector tiles generation and json schema definition and validation
 
 ## Requirements
 
+### General
+
+* Python 3.6+
 * Postgresql 10+
 * PostGIS 2.4+
 * PgRouting 2.5+
+
+### Libraries
+
+these are debian packages required
+
+- libpq-dev   (psycopg2)
+- gettext     (translations)
+- binutils    (django.contrib.gis)
+- libproj-dev (django.contrib.gis)
+- gdal-bin    (django.contrib.gis)
+
+recommended
+
+- postgresql-client (if you want to use ./manage.py dbshell command)
+
+## Installation
+
+### from PYPI
+
+```bash
+pip install django-geocrud
+```
+
+### from GitHub
+
+```bash
+git clone https://github.com/Terralego/django-geostore.git
+cd django-geostore
+python3 setup.py install
+```
+
 
 ## Development
 
 ### with docker :
 ```bash
-$ docker-compose build
-$ docker-compose up
-$ docker-compose run web /code/venv/bin/python3.7 ./manage.py test
+docker-compose build
+docker-compose up
+docker-compose run web ./manage.py test
 ```
 
 ### with pip :
 ```bash
-$ python3.7 -m venv venv
-$ source activate venv/bin/activate
+python3.6 -m venv venv
+source activate venv/bin/activate
 pip install -e .[dev]
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ recommended
 ### from PYPI
 
 ```bash
-pip install django-geocrud
+pip install django-geostore
 ```
 
 ### from GitHub

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # django-geostore
 
-Dynamic geographic datastore with vector tiles generation and json schema definition and validation
+Dynamic geographic datastore with Vector Tiles generation from PostGIS and json schema definition and validation.
 
 ## Requirements
 


### PR DESCRIPTION
* use minimum python version required in dockerfile to avoid compatibility problem
* use virtualenv by default in docker image, to avoid /code/venv/bin/python3.6 usage
* Improve documentation