### PR TITLE
Fixes file link in email template creating issues in email client

### DIFF
--- a/geostore/locale/fr/LC_MESSAGES/django.po
+++ b/geostore/locale/fr/LC_MESSAGES/django.po
@@ -21,6 +21,9 @@ msgstr ""
 msgid "Geographic Store"
 msgstr "Entrepot Géographique"
 
+msgid "Download"
+msgstr "Télécharger"
+
 msgid "Your data export is ready"
 msgstr "Votre export de données est prêt"
 

--- a/geostore/locale/fr/LC_MESSAGES/django.po
+++ b/geostore/locale/fr/LC_MESSAGES/django.po
@@ -21,9 +21,6 @@ msgstr ""
 msgid "Geographic Store"
 msgstr "Entrepot Géographique"
 
-msgid "Download"
-msgstr "Télécharger"
-
 msgid "Your data export is ready"
 msgstr "Votre export de données est prêt"
 

--- a/geostore/templates/geostore/emails/exports.html
+++ b/geostore/templates/geostore/emails/exports.html
@@ -3,6 +3,6 @@
 Hello <strong>{{ username }}</strong>
 <br>
 <br>
-Your file is ready : <a href="{{ url }}">{% translate "Download" %}</a>.
+Your file is ready : <a href="{{ url }}">Download</a>.
 <br>
 {% endblocktrans %}

--- a/geostore/templates/geostore/emails/exports.html
+++ b/geostore/templates/geostore/emails/exports.html
@@ -3,6 +3,6 @@
 Hello <strong>{{ username }}</strong>
 <br>
 <br>
-Your file is ready : <a href="{{ url }}">{{ url }}</a>
+Your file is ready : <a href="{{ url }}">{% translate "Download" %}</a>.
 <br>
 {% endblocktrans %}

--- a/geostore/templates/geostore/emails/exports.html
+++ b/geostore/templates/geostore/emails/exports.html
@@ -5,4 +5,5 @@ Hello <strong>{{ username }}</strong>
 <br>
 Your file is ready : <a href="{{ url }}">Download</a>.
 <br>
+If you can't click on this link, copy-paste the following text into your browser : {{ url }}
 {% endblocktrans %}


### PR DESCRIPTION
When using sendinblue to send email, links are replaced with a tracking
link to allow statistics collection. However this was causing a warning in
email clients : the value of href="http://.." wasn't matching anymore the
value within the tag.

![image](https://user-images.githubusercontent.com/15819864/135854442-476f7221-5a06-436a-8fa0-a2f6f83f32bc.png)
